### PR TITLE
Laravel 5.6 commands must be called from handle method.

### DIFF
--- a/src/Commands/MakeMigrationJsonCommand.php
+++ b/src/Commands/MakeMigrationJsonCommand.php
@@ -78,6 +78,16 @@ class MakeMigrationJsonCommand extends Command
         // Set Filesystem instance
         $this->filesystem = $filesystem;
     }
+    
+    /**
+     * Laravel 5.6 commands must be called from handle method.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        return $this->fire();   
+    }
 
     /**
     * Execute the console command.


### PR DESCRIPTION
Fixes this:

```
php artisan make:migration:json

   ReflectionException  : Method Mojopollo\Schema\Commands\MakeMigrationJsonCommand::handle() does not exist

  at /var/www/testing.xppia.com/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:135
    131|             $callback = explode('::', $callback);
    132|         }
    133|
    134|         return is_array($callback)
  > 135|                         ? new ReflectionMethod($callback[0], $callback[1])
    136|                         : new ReflectionFunction($callback);
    137|     }
    138|
    139|     /**

  Exception trace:

  1   ReflectionMethod::__construct(Object(Mojopollo\Schema\Commands\MakeMigrationJsonCommand), "handle")
      /var/www/testing.xppia.com/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:135

  2   Illuminate\Container\BoundMethod::getCallReflector()
      /var/www/testing.xppia.com/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:115

  Please use the argument -v to see more details.
```